### PR TITLE
chore: update example deps

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,7 @@
 // This is an example app, so we don't need public member API docs.
 // ignore_for_file: public_member_api_docs
 
+import 'dart:async';
 import 'dart:developer' as developer;
 
 import 'package:flutter/material.dart';
@@ -38,12 +39,12 @@ class _MyHomePageState extends State<MyHomePage> {
   @override
   void initState() {
     super.initState();
-    TheStorage.i().init();
+    unawaited(TheStorage.i().init());
   }
 
   @override
   void dispose() {
-    TheStorage.i().dispose();
+    unawaited(TheStorage.i().dispose());
     super.dispose();
   }
 
@@ -53,8 +54,9 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 
   Future<void> readDb() async {
-    developer
-        .log("read from DB: myKey: '${await TheStorage.i().get('myKey')}'");
+    developer.log(
+      "read from DB: myKey: '${await TheStorage.i().get('myKey')}'",
+    );
   }
 
   Future<void> clearDb() async {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -130,10 +130,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: "5398f14efa795ffb7a33e9b6a08798b26a180edac4ad7db3f231e40f82ce11e1"
+      sha256: "3105dc8492f6183fb076ccf1f351ac3d60564bff92e20bfc4af9cc1651f4e7e1"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.0"
+    version: "6.0.0"
   flutter_secure_storage:
     dependency: transitive
     description:
@@ -244,10 +244,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: c35bb79562d980e9a453fc715854e1ed39e24e7d0297a880ef54e17f9874a9d7
+      sha256: "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df"
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.1"
+    version: "6.1.0"
   logging:
     dependency: transitive
     description:
@@ -520,10 +520,10 @@ packages:
     dependency: "direct dev"
     description:
       name: very_good_analysis
-      sha256: "62d2b86d183fb81b2edc22913d9f155d26eb5cf3855173adb1f59fac85035c63"
+      sha256: d1cb1d66a5aae2c702d68caca6c8347306d35e728fd94555fa21fa0448a972e0
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "10.2.0"
   vm_service:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -19,7 +19,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.6.1
+  sdk: ^3.11.0
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -45,12 +45,12 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
 
   flutter_test:
     sdk: flutter
 
-  very_good_analysis: ^7.0.0
+  very_good_analysis: ^10.2.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
## Summary
- Bump example SDK to ^3.11.0
- Upgrade flutter_lints ^5.0.0 → ^6.0.0, very_good_analysis ^7.0.0 → ^10.2.0
- Fix discarded_futures lint issues

## Test plan
- [x] `flutter analyze` — no issues